### PR TITLE
Call `setAppInfo` on Stripe client when it is created

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nestjs-stripe",
   "version": "0.1.0",
   "description": "Provides an injectable Stripe client to nestjs modules",
-  "repository": "git@github.com:dhaspden/nestjs-stripe.git",
+  "repository": "https://github.com/dhaspden/nestjs-stripe",
   "author": {
     "name": "Dylan Aspden",
     "url": "http://github.com/dhaspden"

--- a/src/util/getStripeClient.ts
+++ b/src/util/getStripeClient.ts
@@ -1,7 +1,17 @@
 import * as Stripe from 'stripe';
 
+import { author, name, version } from './../../package.json';
 import { StripeOptions } from './../interfaces';
 
 export function getStripeClient(options: StripeOptions): Stripe {
+  const stripeClient = new Stripe(options.apiKey, options.version);
+
+  // TODO: update this when @types/stripe adds `setAppInfo`
+  (stripeClient as any).setAppInfo({
+    name,
+    url: author.url,
+    version,
+  });
+
   return new Stripe(options.apiKey, options.version);
 }

--- a/src/util/getStripeClient.ts
+++ b/src/util/getStripeClient.ts
@@ -1,6 +1,6 @@
 import * as Stripe from 'stripe';
 
-import { author, name, version } from './../../package.json';
+import { name, repository, version } from './../../package.json';
 import { StripeOptions } from './../interfaces';
 
 export function getStripeClient(options: StripeOptions): Stripe {
@@ -9,7 +9,7 @@ export function getStripeClient(options: StripeOptions): Stripe {
   // TODO: update this when @types/stripe adds `setAppInfo`
   (stripeClient as any).setAppInfo({
     name,
-    url: author.url,
+    url: repository,
     version,
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "commonjs",
     "outDir": "./lib",
     "removeComments": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "target": "es6"
   },


### PR DESCRIPTION
When we generate the Stripe client we now call `setAppInfo` according to the `stripe-node` README.  We load some information from `package.json` and inject it into the Stripe client.