### PR TITLE
Add new options to apply to the Stripe client

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "https-proxy-agent": "2.2.1",
     "stripe": "7.4.0"
   },
   "devDependencies": {

--- a/src/StripeModule.spec.ts
+++ b/src/StripeModule.spec.ts
@@ -17,7 +17,7 @@ describe('StripeModule', () => {
   }
 
   describe('forRoot', () => {
-    it('provides the stripe client', async () => {
+    it('should provide the stripe client', async () => {
       const module = await Test.createTestingModule({
         imports: [StripeModule.forRoot({ apiKey })],
       }).compile();
@@ -29,32 +29,36 @@ describe('StripeModule', () => {
   });
 
   describe('forRootAsync', () => {
-    it('can be used with useFactory', async () => {
-      const module = await Test.createTestingModule({
-        imports: [
-          StripeModule.forRootAsync({
-            useFactory: () => ({ apiKey }),
-          }),
-        ],
-      }).compile();
+    describe('when the `useFactory` option is used', () => {
+      it('should provide the stripe client', async () => {
+        const module = await Test.createTestingModule({
+          imports: [
+            StripeModule.forRootAsync({
+              useFactory: () => ({ apiKey }),
+            }),
+          ],
+        }).compile();
 
-      const stripeClient = module.get<Stripe>(stripeToken);
-      expect(stripeClient).toBeDefined();
-      expect(stripeClient).toBeInstanceOf(Stripe);
+        const stripeClient = module.get<Stripe>(stripeToken);
+        expect(stripeClient).toBeDefined();
+        expect(stripeClient).toBeInstanceOf(Stripe);
+      });
     });
 
-    it('can be used with useClass', async () => {
-      const module = await Test.createTestingModule({
-        imports: [
-          StripeModule.forRootAsync({
-            useClass: TestService,
-          }),
-        ],
-      }).compile();
+    describe('when the `useClass` option is used', () => {
+      it('should provide the stripe client', async () => {
+        const module = await Test.createTestingModule({
+          imports: [
+            StripeModule.forRootAsync({
+              useClass: TestService,
+            }),
+          ],
+        }).compile();
 
-      const stripeClient = module.get<Stripe>(stripeToken);
-      expect(stripeClient).toBeDefined();
-      expect(stripeClient).toBeInstanceOf(Stripe);
+        const stripeClient = module.get<Stripe>(stripeToken);
+        expect(stripeClient).toBeDefined();
+        expect(stripeClient).toBeInstanceOf(Stripe);
+      });
     });
   });
 });

--- a/src/decorators/InjectStripe.spec.ts
+++ b/src/decorators/InjectStripe.spec.ts
@@ -21,9 +21,11 @@ describe('InjectStripe', () => {
     }).compile();
   });
 
-  it('injects the stripe client into the class', () => {
-    const testService = module.get(TestService);
-    expect(testService).toHaveProperty('stripeClient');
-    expect(testService.stripeClient).toBeInstanceOf(Stripe);
+  describe('when decorating a class constructor parameter', () => {
+    it('should inject the stripe client', () => {
+      const testService = module.get(TestService);
+      expect(testService).toHaveProperty('stripeClient');
+      expect(testService.stripeClient).toBeInstanceOf(Stripe);
+    });
   });
 });

--- a/src/interfaces/StripeOptions.ts
+++ b/src/interfaces/StripeOptions.ts
@@ -1,6 +1,8 @@
 export interface StripeOptions {
   readonly apiKey: string;
+  readonly httpProxy?: string;
   readonly maxNetworkRetries?: number;
   readonly requestTelemetry?: boolean;
+  readonly requestTimeout?: number;
   readonly version?: string;
 }

--- a/src/interfaces/StripeOptions.ts
+++ b/src/interfaces/StripeOptions.ts
@@ -1,5 +1,6 @@
 export interface StripeOptions {
   readonly apiKey: string;
+  readonly maxNetworkRetries?: number;
   readonly requestTelemetry?: boolean;
   readonly version?: string;
 }

--- a/src/interfaces/StripeOptions.ts
+++ b/src/interfaces/StripeOptions.ts
@@ -1,4 +1,5 @@
 export interface StripeOptions {
   readonly apiKey: string;
+  readonly requestTelemetry?: boolean;
   readonly version?: string;
 }

--- a/src/providers/createStripeProvider.spec.ts
+++ b/src/providers/createStripeProvider.spec.ts
@@ -6,14 +6,16 @@ import { createStripeProvider } from './createStripeProvider';
 describe('stripeProvider', () => {
   const apiKey = 'test';
 
-  it('uses the correct token', () => {
-    const provider = createStripeProvider({ apiKey });
-    expect(provider).toHaveProperty('provide', stripeToken);
-  });
+  describe('when called', () => {
+    it('should use the correct token', () => {
+      const provider = createStripeProvider({ apiKey });
+      expect(provider).toHaveProperty('provide', stripeToken);
+    });
 
-  it('provides a stripe client', () => {
-    const provider = createStripeProvider({ apiKey });
-    expect(provider).toHaveProperty('useValue');
-    expect((provider as any).useValue).toBeInstanceOf(Stripe);
+    it('should provide a stripe client', () => {
+      const provider = createStripeProvider({ apiKey });
+      expect(provider).toHaveProperty('useValue');
+      expect((provider as any).useValue).toBeInstanceOf(Stripe);
+    });
   });
 });

--- a/src/util/getStripeClient.spec.ts
+++ b/src/util/getStripeClient.spec.ts
@@ -1,0 +1,35 @@
+import * as Stripe from 'stripe';
+
+import { getStripeClient } from './getStripeClient';
+
+describe('getStripeClient', () => {
+  const apiKey = 'test';
+
+  describe('when `requestTelemetry` is a boolean', () => {
+    it('should call stripe.setTelemetryEnabled', () => {
+      const spy = jest.spyOn(Stripe.prototype as any, 'setTelemetryEnabled');
+      getStripeClient({
+        apiKey,
+        requestTelemetry: false,
+      });
+
+      expect(
+        (Stripe.prototype as any).setTelemetryEnabled,
+      ).toHaveBeenNthCalledWith(2, false);
+      spy.mockReset();
+    });
+  });
+
+  describe('when `requestTelemetry` is not provided', () => {
+    it('should not call stripe.setTelemetryEnabled', () => {
+      const spy = jest.spyOn(Stripe.prototype as any, 'setTelemetryEnabled');
+      getStripeClient({ apiKey });
+
+      // Called by the `Stripe` constructor automatically
+      expect(
+        (Stripe.prototype as any).setTelemetryEnabled,
+      ).toHaveBeenCalledTimes(1);
+      spy.mockReset();
+    });
+  });
+});

--- a/src/util/getStripeClient.spec.ts
+++ b/src/util/getStripeClient.spec.ts
@@ -12,6 +12,30 @@ describe('getStripeClient', () => {
     });
   });
 
+  describe('when `httpProxy` is a string', () => {
+    it('should call stripe.setHttpAgent', () => {
+      const spy = jest.spyOn(Stripe.prototype as any, 'setHttpAgent');
+      const httpProxy = 'https://google.ca';
+      getStripeClient({
+        apiKey,
+        httpProxy,
+      });
+
+      expect((Stripe.prototype as any).setHttpAgent).toHaveBeenCalled();
+      spy.mockReset();
+    });
+  });
+
+  describe('when `httpProxy` is not provided', () => {
+    it('should not call stripe.setHttpAgent', () => {
+      const spy = jest.spyOn(Stripe.prototype as any, 'setHttpAgent');
+      getStripeClient({ apiKey });
+
+      expect((Stripe.prototype as any).setHttpAgent).not.toHaveBeenCalled();
+      spy.mockReset();
+    });
+  });
+
   describe('when `maxNetworkRetries` is a number', () => {
     it('should call stripe.setMaxNetworkRetries', () => {
       const spy = jest.spyOn(Stripe.prototype, 'setMaxNetworkRetries');
@@ -59,6 +83,29 @@ describe('getStripeClient', () => {
       expect(
         (Stripe.prototype as any).setTelemetryEnabled,
       ).toHaveBeenCalledTimes(1);
+      spy.mockReset();
+    });
+  });
+
+  describe('when `requestTimeout` is a number', () => {
+    it('should call stripe.setTimeout', () => {
+      const spy = jest.spyOn(Stripe.prototype, 'setTimeout');
+      getStripeClient({
+        apiKey,
+        requestTimeout: 10000,
+      });
+
+      expect(Stripe.prototype.setTimeout).toHaveBeenCalledWith(10000);
+      spy.mockReset();
+    });
+  });
+
+  describe('when `requestTimeout` is not provided', () => {
+    it('should not call stripe.setTimeout', () => {
+      const spy = jest.spyOn(Stripe.prototype, 'setTimeout');
+      getStripeClient({ apiKey });
+
+      expect(Stripe.prototype.setTimeout).not.toHaveBeenCalled();
       spy.mockReset();
     });
   });

--- a/src/util/getStripeClient.spec.ts
+++ b/src/util/getStripeClient.spec.ts
@@ -5,6 +5,36 @@ import { getStripeClient } from './getStripeClient';
 describe('getStripeClient', () => {
   const apiKey = 'test';
 
+  describe('when `apiKey` is provided', () => {
+    it('should return the stripe client', () => {
+      const stripeClient = getStripeClient({ apiKey });
+      expect(stripeClient).toBeInstanceOf(Stripe);
+    });
+  });
+
+  describe('when `maxNetworkRetries` is a number', () => {
+    it('should call stripe.setMaxNetworkRetries', () => {
+      const spy = jest.spyOn(Stripe.prototype, 'setMaxNetworkRetries');
+      getStripeClient({
+        apiKey,
+        maxNetworkRetries: 1,
+      });
+
+      expect(Stripe.prototype.setMaxNetworkRetries).toHaveBeenCalledWith(1);
+      spy.mockReset();
+    });
+  });
+
+  describe('when `maxNetworkRetries` is not provided', () => {
+    it('should not call stripe.setMaxNetworkRetries', () => {
+      const spy = jest.spyOn(Stripe.prototype, 'setMaxNetworkRetries');
+      getStripeClient({ apiKey });
+
+      expect(Stripe.prototype.setMaxNetworkRetries).not.toHaveBeenCalled();
+      spy.mockReset();
+    });
+  });
+
   describe('when `requestTelemetry` is a boolean', () => {
     it('should call stripe.setTelemetryEnabled', () => {
       const spy = jest.spyOn(Stripe.prototype as any, 'setTelemetryEnabled');

--- a/src/util/getStripeClient.ts
+++ b/src/util/getStripeClient.ts
@@ -13,6 +13,10 @@ export function getStripeClient(options: StripeOptions): Stripe {
     version,
   });
 
+  if (typeof options.maxNetworkRetries === 'number') {
+    stripeClient.setMaxNetworkRetries(options.maxNetworkRetries);
+  }
+
   if (typeof options.requestTelemetry === 'boolean') {
     // TODO: update this when @types/stripe adds `setTelemetryEnabled`
     (stripeClient as any).setTelemetryEnabled(options.requestTelemetry);

--- a/src/util/getStripeClient.ts
+++ b/src/util/getStripeClient.ts
@@ -1,3 +1,4 @@
+import * as ProxyAgent from 'https-proxy-agent';
 import * as Stripe from 'stripe';
 
 import { name, repository, version } from './../../package.json';
@@ -13,6 +14,11 @@ export function getStripeClient(options: StripeOptions): Stripe {
     version,
   });
 
+  if (typeof options.httpProxy === 'string') {
+    // TODO: update this when @types/stripe adds `setHttpAgent`
+    (stripeClient as any).setHttpAgent(new ProxyAgent(options.httpProxy));
+  }
+
   if (typeof options.maxNetworkRetries === 'number') {
     stripeClient.setMaxNetworkRetries(options.maxNetworkRetries);
   }
@@ -20,6 +26,10 @@ export function getStripeClient(options: StripeOptions): Stripe {
   if (typeof options.requestTelemetry === 'boolean') {
     // TODO: update this when @types/stripe adds `setTelemetryEnabled`
     (stripeClient as any).setTelemetryEnabled(options.requestTelemetry);
+  }
+
+  if (typeof options.requestTimeout === 'number') {
+    stripeClient.setTimeout(options.requestTimeout);
   }
 
   return stripeClient;

--- a/src/util/getStripeClient.ts
+++ b/src/util/getStripeClient.ts
@@ -13,5 +13,10 @@ export function getStripeClient(options: StripeOptions): Stripe {
     version,
   });
 
-  return new Stripe(options.apiKey, options.version);
+  if (typeof options.requestTelemetry === 'boolean') {
+    // TODO: update this when @types/stripe adds `setTelemetryEnabled`
+    (stripeClient as any).setTelemetryEnabled(options.requestTelemetry);
+  }
+
+  return stripeClient;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,7 +1547,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^2.2.1:
+https-proxy-agent@2.2.1, https-proxy-agent@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==


### PR DESCRIPTION
When the Stripe client is created we now allow for the following options:

- `httpProxy` whether or not to use `https-proxy-agent` as per the documentation
- `maxNetworkRetries` the number of times a request will be retried by the library before failing
- `requestTelemetry` whether or not to enable request telemetry (enabled by default by Stripe)
- `requestTimeout` the time in ms for a request to be timed out