### PR TITLE
Update the Stripe typings to avoid casting to `any`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,15 @@
     "test": "jest"
   },
   "dependencies": {
-    "https-proxy-agent": "2.2.1",
     "stripe": "7.4.0"
   },
   "devDependencies": {
-    "@nestjs/common": "6.4.0",
-    "@nestjs/core": "6.4.0",
-    "@nestjs/testing": "6.4.0",
+    "@nestjs/common": "6.5.2",
+    "@nestjs/core": "6.5.2",
+    "@nestjs/testing": "6.5.2",
     "@types/jest": "24.0.15",
-    "@types/node": "12.0.10",
-    "@types/stripe": "6.30.6",
+    "@types/node": "12.6.2",
+    "@types/stripe": "6.31.3",
     "codecov": "3.5.0",
     "jest": "24.8.0",
     "prettier": "1.18.2",
@@ -39,7 +38,7 @@
     "rimraf": "2.6.3",
     "rxjs": "6.5.2",
     "ts-jest": "24.0.2",
-    "typescript": "3.5.2"
+    "typescript": "3.5.3"
   },
   "peerDependencies": {
     "@nestjs/common": "^6.0.0",

--- a/src/util/getStripeClient.ts
+++ b/src/util/getStripeClient.ts
@@ -1,4 +1,3 @@
-import * as ProxyAgent from 'https-proxy-agent';
 import * as Stripe from 'stripe';
 
 import { StripeOptions } from './../interfaces';
@@ -8,16 +7,14 @@ const packageJson = require('./../../package.json');
 export function getStripeClient(options: StripeOptions): Stripe {
   const stripeClient = new Stripe(options.apiKey, options.version);
 
-  // TODO: update this when @types/stripe adds `setAppInfo`
-  (stripeClient as any).setAppInfo({
+  stripeClient.setAppInfo({
     name: packageJson.name,
     url: packageJson.repository,
     version: packageJson.version,
   });
 
   if (typeof options.httpProxy === 'string') {
-    // TODO: update this when @types/stripe adds `setHttpAgent`
-    (stripeClient as any).setHttpAgent(new ProxyAgent(options.httpProxy));
+    stripeClient.setHttpAgent(options.httpProxy);
   }
 
   if (typeof options.maxNetworkRetries === 'number') {
@@ -25,8 +22,7 @@ export function getStripeClient(options: StripeOptions): Stripe {
   }
 
   if (typeof options.requestTelemetry === 'boolean') {
-    // TODO: update this when @types/stripe adds `setTelemetryEnabled`
-    (stripeClient as any).setTelemetryEnabled(options.requestTelemetry);
+    stripeClient.setTelemetryEnabled(options.requestTelemetry);
   }
 
   if (typeof options.requestTimeout === 'number') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,19 +285,19 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@nestjs/common@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@nestjs/common/-/common-6.4.0.tgz#d8460d107309a34f57868470248fceeb69aac75a"
-  integrity sha512-mv2r0FBVak3YolimWCfIW7F1R4RHV2KmYXztliQMBFqs3AA/606mr3KPTcPtXCgjaMSS0VA9N2Scy0SIdvR/Kg==
+"@nestjs/common@6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/common/-/common-6.5.2.tgz#a864a62f859a7662f658febc0e9a115eee00739e"
+  integrity sha512-vkB6JLPPckjS35usLMV3Q6vljkgzhN3jgQ+U1VY6cKriyjnkIcUKo37tNQSPYkaAGe1pOLK4IkmwMTSyhNieyg==
   dependencies:
     axios "0.19.0"
     cli-color "1.4.0"
     uuid "3.3.2"
 
-"@nestjs/core@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-6.4.0.tgz#e24d6f266034f528eb5ceb216d314dd989aea0f4"
-  integrity sha512-u6IdGxkrLcJUlCqR3z9EfX3T2chYU2AbQCAo7BmFx05JLRXVdfpTah65RFwSrqMRQZiubxifDVC8HMBDlhkbNw==
+"@nestjs/core@6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/core/-/core-6.5.2.tgz#42ff3ce1b1a51055bbc4732e60d1029fb8ca487d"
+  integrity sha512-LTRCl4oaFP43DcPHbvVO0sH72M+N0uGwnqc0UxhJ7ovJMX6xhahSot1QTkBb56V2AIfmzaRbGpuA4qhIgBXj6A==
   dependencies:
     "@nuxtjs/opencollective" "0.2.2"
     fast-safe-stringify "2.0.6"
@@ -306,10 +306,10 @@
     optional "0.1.4"
     uuid "3.3.2"
 
-"@nestjs/testing@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@nestjs/testing/-/testing-6.4.0.tgz#20fb7d43007805701448fa2c60cdd6c9cd08033a"
-  integrity sha512-YmN7t4aBx3bhy0sRFYhIgCCAoaedalqNFBt7ifgMtOfbce65CqhfJe/hUt2zoHPKLEhzCmxbZimlj6Fx9Vu1ZA==
+"@nestjs/testing@6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@nestjs/testing/-/testing-6.5.2.tgz#5a66f9214c534efdd509fa4116bb14c20b3780f5"
+  integrity sha512-wyob7CkuCdq+NBhq78JyX5Llk4tQv2fS1jcVqhvHp96zc9RxemOMvN1GUHTXo4SNVxE+hlUV1smvcsPPsmlj8Q==
   dependencies:
     optional "0.1.4"
 
@@ -387,20 +387,25 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/node@*", "@types/node@12.0.10":
+"@types/node@*":
   version "12.0.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.10.tgz#51babf9c7deadd5343620055fc8aff7995c8b031"
   integrity sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==
+
+"@types/node@12.6.2":
+  version "12.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.2.tgz#a5ccec6abb6060d5f20d256fb03ed743e9774999"
+  integrity sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/stripe@6.30.6":
-  version "6.30.6"
-  resolved "https://registry.yarnpkg.com/@types/stripe/-/stripe-6.30.6.tgz#502e6957d6f7dfbf90e0b5de406445b47e7dadca"
-  integrity sha512-XShQKQSQFsTllXQzrcJIaBEp3/J6KaCooAiJaKbRNr9doBYMnGXwnAF63YSZYRqmpQVInC3Qn4hHvlHbSTg9Eg==
+"@types/stripe@6.31.3":
+  version "6.31.3"
+  resolved "https://registry.yarnpkg.com/@types/stripe/-/stripe-6.31.3.tgz#959fb6b6ade71062fdf1a93a21b2c68cd76bbcba"
+  integrity sha512-Ash+KkxFtqZPnb8t1WTREF5/nWzlfsyTcuD8zZpG/S9dbt53dj3ei0f8yE8gMjpYrDSjW4AtWcPbIXGLumSVxA==
   dependencies:
     "@types/node" "*"
 
@@ -1547,7 +1552,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@2.2.1, https-proxy-agent@^2.2.1:
+https-proxy-agent@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
@@ -3693,10 +3698,10 @@ type@^1.0.1:
   resolved "https://registry.yarnpkg.com/type/-/type-1.0.1.tgz#084c9a17fcc9151a2cdb1459905c2e45e4bb7d61"
   integrity sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
This pull request fixes some places where we had to cast to an `any` because the Stripe typings library did not support some of the functions we were using.  Those have since been added and we are now using them.