### PR TITLE
Add Greenkeeper lockfile support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,12 @@ jobs:
       - image: circleci/node:10.16.0
     steps:
       - checkout
+      - run:
+          name: Installs Greenkeeper lockfile dependency globally
+          command: sudo yarn global add greenkeeper-lockfile@2
+      - run:
+          name: Updates the lockfile through Greenkeeper
+          command: greenkeeper-lockfile-update
       - restore_cache:
           name: Restores the Yarn package cache if possible
           key: dependency-cache-{{ checksum "package.json" }}


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our Contributing section?
- [x] Have you checked to ensure there aren't other open
      [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you linted your code locally prior to submission?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

---

Added lockfile support for Greenkeeper.  This should stop all of the bogus build fails due to `--frozen-lockfile`.
