### PR TITLE
Export stripeToken to allow for easier unit testing

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,4 +3,4 @@ import Stripe from 'stripe';
 export * from './stripeModuleOptions';
 export * from './stripeToken';
 
-export const apiVersion: Stripe.LatestApiVersion = '2020-08-27';
+export const apiVersion: Stripe.LatestApiVersion = '2020-03-02';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,4 +3,4 @@ import Stripe from 'stripe';
 export * from './stripeModuleOptions';
 export * from './stripeToken';
 
-export const apiVersion: Stripe.LatestApiVersion = '2020-03-02';
+export const apiVersion: Stripe.LatestApiVersion = '2020-08-27';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
+export * from './constants/stripeToken';
 export * from './decorators';
 export * from './interfaces';
 export * from './StripeModule';
-
-export * from './constants/stripeToken';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export * from './decorators';
 export * from './interfaces';
 export * from './StripeModule';
+
+export * from './constants/stripeToken';


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our Contributing section?
- [x] Have you checked to ensure there aren't other open
      [Pull Requests](../../../pulls) for the same update/change?

---

I was attempting to run unit tests, but in order to override `@InjectStripe`, I had to import the `stripeToken` from `nestjs-stripe/lib/constants`.

There is also a change in the apiVersion because the build would fail unless it was updated.